### PR TITLE
Fixes test failure in get_deps.sh

### DIFF
--- a/get_deps.sh
+++ b/get_deps.sh
@@ -28,6 +28,8 @@ cd test
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBTF_DIRECTORY/lib
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$LIBTF_DIRECTORY/lib
 fi
 gcc -I$LIBTF_DIRECTORY/include -L$LIBTF_DIRECTORY/lib tf_api_test.c -ltensorflow && ./a.out && rm a.out
 


### PR DESCRIPTION
Output w/o this PR (MacOS):

```sh
$ sh get_deps.sh
...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.5M  100 21.5M    0     0  2101k      0  0:00:10  0:00:10 --:--:-- 2215k
dyld: Library not loaded: @rpath/libtensorflow.so
  Referenced from: /Users/itamar/work/RedisTF/test/./a.out
  Reason: image not found
get_deps.sh: line 32: 11550 Abort trap: 6           ./a.out
```

Signed-off-by: Itamar Haber <itamar@redislabs.com>